### PR TITLE
Remove vty arg from bgp_static_set

### DIFF
--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -2072,7 +2072,8 @@ DEFUN(evpnrt5_network,
       "Route-map to modify the attributes\n"
       "Name of the route map\n")
 {
-	int idx_ipv4_prefixlen = 1;
+       VTY_DECLVAR_CONTEXT(bgp, bgp);
+       int idx_ipv4_prefixlen = 1;
 	int idx_route_distinguisher = 3;
 	int idx_label = 7;
 	int idx_esi = 9;
@@ -2080,12 +2081,12 @@ DEFUN(evpnrt5_network,
 	int idx_ethtag = 5;
 	int idx_routermac = 13;
 
-	return bgp_static_set(vty, false, argv[idx_ipv4_prefixlen]->arg,
-			      argv[idx_route_distinguisher]->arg,
-			      argv[idx_label]->arg, AFI_L2VPN, SAFI_EVPN, NULL,
-			      0, 0, BGP_EVPN_IP_PREFIX_ROUTE,
-			      argv[idx_esi]->arg, argv[idx_gwip]->arg,
-			      argv[idx_ethtag]->arg, argv[idx_routermac]->arg);
+       return bgp_static_set(bgp, false, argv[idx_ipv4_prefixlen]->arg,
+                              argv[idx_route_distinguisher]->arg,
+                              argv[idx_label]->arg, AFI_L2VPN, SAFI_EVPN, NULL,
+                              0, 0, BGP_EVPN_IP_PREFIX_ROUTE,
+                              argv[idx_esi]->arg, argv[idx_gwip]->arg,
+                              argv[idx_ethtag]->arg, argv[idx_routermac]->arg);
 }
 
 /* For testing purpose, static route of EVPN RT-5. */
@@ -2106,18 +2107,19 @@ DEFUN(no_evpnrt5_network,
       "ESI value ( 00:11:22:33:44:55:66:77:88:99 format) \n"
       "Gateway IP\n" "Gateway IP ( A.B.C.D )\n" "Gateway IPv6 ( X:X::X:X )\n")
 {
-	int idx_ipv4_prefixlen = 2;
+       VTY_DECLVAR_CONTEXT(bgp, bgp);
+       int idx_ipv4_prefixlen = 2;
 	int idx_ext_community = 4;
 	int idx_label = 8;
 	int idx_ethtag = 6;
 	int idx_esi = 10;
 	int idx_gwip = 12;
 
-	return bgp_static_set(vty, true, argv[idx_ipv4_prefixlen]->arg,
-			      argv[idx_ext_community]->arg,
-			      argv[idx_label]->arg, AFI_L2VPN, SAFI_EVPN, NULL,
-			      0, 0, BGP_EVPN_IP_PREFIX_ROUTE, argv[idx_esi]->arg,
-			      argv[idx_gwip]->arg, argv[idx_ethtag]->arg, NULL);
+       return bgp_static_set(bgp, true, argv[idx_ipv4_prefixlen]->arg,
+                              argv[idx_ext_community]->arg,
+                              argv[idx_label]->arg, AFI_L2VPN, SAFI_EVPN, NULL,
+                              0, 0, BGP_EVPN_IP_PREFIX_ROUTE, argv[idx_esi]->arg,
+                              argv[idx_gwip]->arg, argv[idx_ethtag]->arg, NULL);
 }
 
 static void evpn_import_rt_delete_auto(struct bgp *bgp, struct bgpevpn *vpn)

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -3262,14 +3262,15 @@ DEFUN (vpnv4_network,
        "VPN NLRI label (tag)\n"
        "Label value\n")
 {
-	int idx_ipv4_prefixlen = 1;
+       VTY_DECLVAR_CONTEXT(bgp, bgp);
+       int idx_ipv4_prefixlen = 1;
 	int idx_ext_community = 3;
 	int idx_label = 5;
 
-	return bgp_static_set(vty, false, argv[idx_ipv4_prefixlen]->arg,
-			      argv[idx_ext_community]->arg,
-			      argv[idx_label]->arg, AFI_IP, SAFI_MPLS_VPN, NULL,
-			      0, 0, 0, NULL, NULL, NULL, NULL);
+       return bgp_static_set(bgp, false, argv[idx_ipv4_prefixlen]->arg,
+                             argv[idx_ext_community]->arg,
+                             argv[idx_label]->arg, AFI_IP, SAFI_MPLS_VPN, NULL,
+                             0, 0, 0, NULL, NULL, NULL, NULL);
 }
 
 DEFUN (vpnv4_network_route_map,
@@ -3285,15 +3286,16 @@ DEFUN (vpnv4_network_route_map,
        "route map\n"
        "route map name\n")
 {
-	int idx_ipv4_prefixlen = 1;
+       VTY_DECLVAR_CONTEXT(bgp, bgp);
+       int idx_ipv4_prefixlen = 1;
 	int idx_ext_community = 3;
 	int idx_label = 5;
 	int idx_rmap = 7;
 
-	return bgp_static_set(vty, false, argv[idx_ipv4_prefixlen]->arg,
-			      argv[idx_ext_community]->arg, argv[idx_label]->arg,
-			      AFI_IP, SAFI_MPLS_VPN, argv[idx_rmap]->arg, 0, 0,
-			      0, NULL, NULL, NULL, NULL);
+       return bgp_static_set(bgp, false, argv[idx_ipv4_prefixlen]->arg,
+                              argv[idx_ext_community]->arg, argv[idx_label]->arg,
+                              AFI_IP, SAFI_MPLS_VPN, argv[idx_rmap]->arg, 0, 0,
+                              0, NULL, NULL, NULL, NULL);
 }
 
 /* For testing purpose, static route of MPLS-VPN. */
@@ -3309,14 +3311,15 @@ DEFUN (no_vpnv4_network,
        "VPN NLRI label (tag)\n"
        "Label value\n")
 {
-	int idx_ipv4_prefixlen = 2;
-	int idx_ext_community = 4;
-	int idx_label = 6;
+       VTY_DECLVAR_CONTEXT(bgp, bgp);
+       int idx_ipv4_prefixlen = 2;
+       int idx_ext_community = 4;
+       int idx_label = 6;
 
-	return bgp_static_set(vty, true, argv[idx_ipv4_prefixlen]->arg,
-			      argv[idx_ext_community]->arg,
-			      argv[idx_label]->arg, AFI_IP, SAFI_MPLS_VPN, NULL,
-			      0, 0, 0, NULL, NULL, NULL, NULL);
+       return bgp_static_set(bgp, true, argv[idx_ipv4_prefixlen]->arg,
+                              argv[idx_ext_community]->arg,
+                              argv[idx_label]->arg, AFI_IP, SAFI_MPLS_VPN, NULL,
+                              0, 0, 0, NULL, NULL, NULL, NULL);
 }
 
 DEFUN (vpnv6_network,
@@ -3332,23 +3335,24 @@ DEFUN (vpnv6_network,
        "route map\n"
        "route map name\n")
 {
-	int idx_ipv6_prefix = 1;
+       VTY_DECLVAR_CONTEXT(bgp, bgp);
+       int idx_ipv6_prefix = 1;
 	int idx_ext_community = 3;
 	int idx_label = 5;
 	int idx_rmap = 7;
 
 	if (argc == 8)
-		return bgp_static_set(vty, false, argv[idx_ipv6_prefix]->arg,
-				      argv[idx_ext_community]->arg,
-				      argv[idx_label]->arg, AFI_IP6,
-				      SAFI_MPLS_VPN, argv[idx_rmap]->arg, 0, 0,
-				      0, NULL, NULL, NULL, NULL);
+               return bgp_static_set(bgp, false, argv[idx_ipv6_prefix]->arg,
+                                      argv[idx_ext_community]->arg,
+                                      argv[idx_label]->arg, AFI_IP6,
+                                      SAFI_MPLS_VPN, argv[idx_rmap]->arg, 0, 0,
+                                      0, NULL, NULL, NULL, NULL);
 	else
-		return bgp_static_set(vty, false, argv[idx_ipv6_prefix]->arg,
-				      argv[idx_ext_community]->arg,
-				      argv[idx_label]->arg, AFI_IP6,
-				      SAFI_MPLS_VPN, NULL, 0, 0, 0, NULL, NULL,
-				      NULL, NULL);
+               return bgp_static_set(bgp, false, argv[idx_ipv6_prefix]->arg,
+                                      argv[idx_ext_community]->arg,
+                                      argv[idx_label]->arg, AFI_IP6,
+                                      SAFI_MPLS_VPN, NULL, 0, 0, 0, NULL, NULL,
+                                      NULL, NULL);
 }
 
 /* For testing purpose, static route of MPLS-VPN. */
@@ -3364,14 +3368,15 @@ DEFUN (no_vpnv6_network,
        "VPN NLRI label (tag)\n"
        "Label value\n")
 {
-	int idx_ipv6_prefix = 2;
-	int idx_ext_community = 4;
-	int idx_label = 6;
+       VTY_DECLVAR_CONTEXT(bgp, bgp);
+       int idx_ipv6_prefix = 2;
+       int idx_ext_community = 4;
+       int idx_label = 6;
 
-	return bgp_static_set(vty, true, argv[idx_ipv6_prefix]->arg,
-			      argv[idx_ext_community]->arg,
-			      argv[idx_label]->arg, AFI_IP6, SAFI_MPLS_VPN,
-			      NULL, 0, 0, 0, NULL, NULL, NULL, NULL);
+       return bgp_static_set(bgp, true, argv[idx_ipv6_prefix]->arg,
+                              argv[idx_ext_community]->arg,
+                              argv[idx_label]->arg, AFI_IP6, SAFI_MPLS_VPN,
+                              NULL, 0, 0, 0, NULL, NULL, NULL, NULL);
 }
 
 int bgp_show_mpls_vpn(struct vty *vty, afi_t afi, struct prefix_rd *prd,

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7706,13 +7706,12 @@ void bgp_static_withdraw(struct bgp *bgp, const struct prefix *p, afi_t afi,
 
 /* Configure static BGP network.  When user don't run zebra, static
    route should be installed as valid.  */
-int bgp_static_set(struct vty *vty, bool negate, const char *ip_str,
-		   const char *rd_str, const char *label_str, afi_t afi,
-		   safi_t safi, const char *rmap, int backdoor,
-		   uint32_t label_index, int evpn_type, const char *esi,
-		   const char *gwip, const char *ethtag, const char *routermac)
+int bgp_static_set(struct bgp *bgp, bool negate, const char *ip_str,
+                   const char *rd_str, const char *label_str, afi_t afi,
+                   safi_t safi, const char *rmap, int backdoor,
+                   uint32_t label_index, int evpn_type, const char *esi,
+                   const char *gwip, const char *ethtag, const char *routermac)
 {
-	VTY_DECLVAR_CONTEXT(bgp, bgp);
 	int ret;
 	struct prefix p;
 	struct bgp_static *bgp_static;
@@ -7726,30 +7725,30 @@ int bgp_static_set(struct vty *vty, bool negate, const char *ip_str,
 
 	/* Convert IP prefix string to struct prefix. */
 	ret = str2prefix(ip_str, &p);
-	if (!ret) {
-		vty_out(vty, "%% Malformed prefix\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
-	if (afi == AFI_IP6 && IN6_IS_ADDR_LINKLOCAL(&p.u.prefix6)) {
-		vty_out(vty, "%% Malformed prefix (link-local address)\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
+       if (!ret) {
+               zlog_warn("Malformed prefix");
+               return CMD_WARNING_CONFIG_FAILED;
+       }
+       if (afi == AFI_IP6 && IN6_IS_ADDR_LINKLOCAL(&p.u.prefix6)) {
+               zlog_warn("Malformed prefix (link-local address)");
+               return CMD_WARNING_CONFIG_FAILED;
+       }
 
 	apply_mask(&p);
 
-	if (afi == AFI_L2VPN &&
-	    (bgp_build_evpn_prefix(evpn_type, ethtag != NULL ? atol(ethtag) : 0,
-				   &p))) {
-		vty_out(vty, "%% L2VPN prefix could not be forged\n");
-		return CMD_WARNING_CONFIG_FAILED;
-	}
+       if (afi == AFI_L2VPN &&
+           (bgp_build_evpn_prefix(evpn_type, ethtag != NULL ? atol(ethtag) : 0,
+                                  &p))) {
+               zlog_warn("L2VPN prefix could not be forged");
+               return CMD_WARNING_CONFIG_FAILED;
+       }
 
 	if (safi == SAFI_MPLS_VPN || safi == SAFI_EVPN) {
-		ret = str2prefix_rd(rd_str, &prd);
-		if (!ret) {
-			vty_out(vty, "%% Malformed rd\n");
-			return CMD_WARNING_CONFIG_FAILED;
-		}
+               ret = str2prefix_rd(rd_str, &prd);
+               if (!ret) {
+                       zlog_warn("Malformed rd");
+                       return CMD_WARNING_CONFIG_FAILED;
+               }
 
 		if (label_str) {
 			unsigned long label_val;
@@ -7760,29 +7759,28 @@ int bgp_static_set(struct vty *vty, bool negate, const char *ip_str,
 	}
 
 	if (safi == SAFI_EVPN) {
-		if (esi && str2esi(esi, NULL) == 0) {
-			vty_out(vty, "%% Malformed ESI\n");
-			return CMD_WARNING_CONFIG_FAILED;
-		}
-		if (routermac && prefix_str2mac(routermac, NULL) == 0) {
-			vty_out(vty, "%% Malformed Router MAC\n");
-			return CMD_WARNING_CONFIG_FAILED;
-		}
+               if (esi && str2esi(esi, NULL) == 0) {
+                       zlog_warn("Malformed ESI");
+                       return CMD_WARNING_CONFIG_FAILED;
+               }
+               if (routermac && prefix_str2mac(routermac, NULL) == 0) {
+                       zlog_warn("Malformed Router MAC");
+                       return CMD_WARNING_CONFIG_FAILED;
+               }
 		if (gwip) {
 			memset(&gw_ip, 0, sizeof(gw_ip));
 			ret = str2prefix(gwip, &gw_ip);
 			if (!ret) {
-				vty_out(vty, "%% Malformed GatewayIp\n");
-				return CMD_WARNING_CONFIG_FAILED;
+                               zlog_warn("Malformed GatewayIp");
+                               return CMD_WARNING_CONFIG_FAILED;
 			}
 			if ((gw_ip.family == AF_INET &&
 			     is_evpn_prefix_ipaddr_v6((struct prefix_evpn *)&p)) ||
 			    (gw_ip.family == AF_INET6 &&
 			     is_evpn_prefix_ipaddr_v4(
 				     (struct prefix_evpn *)&p))) {
-				vty_out(vty,
-					"%% GatewayIp family differs with IP prefix\n");
-				return CMD_WARNING_CONFIG_FAILED;
+                               zlog_warn("GatewayIp family differs with IP prefix");
+                               return CMD_WARNING_CONFIG_FAILED;
 			}
 		}
 	}
@@ -7803,28 +7801,26 @@ int bgp_static_set(struct vty *vty, bool negate, const char *ip_str,
 		/* Set BGP static route configuration. */
 		dest = bgp_node_lookup(bgp->route[afi][safi], &p);
 
-		if (!dest) {
-			vty_out(vty, "%% Can't find static route specified\n");
-			return CMD_WARNING_CONFIG_FAILED;
-		}
+               if (!dest) {
+                       zlog_warn("Can't find static route specified");
+                       return CMD_WARNING_CONFIG_FAILED;
+               }
 
 		bgp_static = bgp_dest_get_bgp_static_info(dest);
 		if (bgp_static) {
 			if ((label_index != BGP_INVALID_LABEL_INDEX) &&
 			    (label_index != bgp_static->label_index)) {
-				vty_out(vty,
-					"%% label-index doesn't match static route\n");
-				bgp_dest_unlock_node(dest);
-				return CMD_WARNING_CONFIG_FAILED;
-			}
+                               zlog_warn("label-index doesn't match static route");
+                               bgp_dest_unlock_node(dest);
+                               return CMD_WARNING_CONFIG_FAILED;
+                       }
 
 			if ((rmap && bgp_static->rmap.name) &&
 			    strcmp(rmap, bgp_static->rmap.name)) {
-				vty_out(vty,
-					"%% route-map name doesn't match static route\n");
-				bgp_dest_unlock_node(dest);
-				return CMD_WARNING_CONFIG_FAILED;
-			}
+                               zlog_warn("route-map name doesn't match static route");
+                               bgp_dest_unlock_node(dest);
+                               return CMD_WARNING_CONFIG_FAILED;
+                       }
 
 			/* Update BGP RIB. */
 			if (!bgp_static->backdoor)
@@ -7846,10 +7842,10 @@ int bgp_static_set(struct vty *vty, bool negate, const char *ip_str,
 			/* Configuration change. */
 			/* Label index cannot be changed. */
 			if (bgp_static->label_index != label_index) {
-				vty_out(vty, "%% cannot change label-index\n");
-				bgp_dest_unlock_node(dest);
-				return CMD_WARNING_CONFIG_FAILED;
-			}
+                               zlog_warn("cannot change label-index");
+                               bgp_dest_unlock_node(dest);
+                               return CMD_WARNING_CONFIG_FAILED;
+                       }
 
 			/* Check previous routes are installed into BGP.  */
 			if (bgp_static->valid
@@ -8215,7 +8211,8 @@ DEFPY(bgp_network,
 	"Label index value\n"
 	"Specify a BGP backdoor route\n")
 {
-	char addr_prefix_str[BUFSIZ];
+       VTY_DECLVAR_CONTEXT(bgp, bgp);
+       char addr_prefix_str[BUFSIZ];
 
 	if (address_str) {
 		int ret;
@@ -8229,13 +8226,13 @@ DEFPY(bgp_network,
 		}
 	}
 
-	return bgp_static_set(vty, no,
-			      address_str ? addr_prefix_str : prefix_str, NULL,
-			      NULL, AFI_IP, bgp_node_safi(vty), map_name,
-			      backdoor ? 1 : 0,
-			      label_index ? (uint32_t)label_index
-					  : BGP_INVALID_LABEL_INDEX,
-			      0, NULL, NULL, NULL, NULL);
+       return bgp_static_set(bgp, no,
+                             address_str ? addr_prefix_str : prefix_str, NULL,
+                             NULL, AFI_IP, bgp_node_safi(vty), map_name,
+                             backdoor ? 1 : 0,
+                             label_index ? (uint32_t)label_index
+                                         : BGP_INVALID_LABEL_INDEX,
+                             0, NULL, NULL, NULL, NULL);
 }
 
 DEFPY(ipv6_bgp_network,
@@ -8250,11 +8247,12 @@ DEFPY(ipv6_bgp_network,
 	"Label index to associate with the prefix\n"
 	"Label index value\n")
 {
-	return bgp_static_set(vty, no, prefix_str, NULL, NULL, AFI_IP6,
-			      bgp_node_safi(vty), map_name, 0,
-			      label_index ? (uint32_t)label_index
-					  : BGP_INVALID_LABEL_INDEX,
-			      0, NULL, NULL, NULL, NULL);
+       VTY_DECLVAR_CONTEXT(bgp, bgp);
+       return bgp_static_set(bgp, no, prefix_str, NULL, NULL, AFI_IP6,
+                              bgp_node_safi(vty), map_name, 0,
+                              label_index ? (uint32_t)label_index
+                                          : BGP_INVALID_LABEL_INDEX,
+                              0, NULL, NULL, NULL, NULL);
 }
 
 static struct bgp_aggregate *bgp_aggregate_new(void)

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -838,12 +838,12 @@ extern void bgp_static_update(struct bgp *bgp, const struct prefix *p,
 extern void bgp_static_withdraw(struct bgp *bgp, const struct prefix *p,
 				afi_t afi, safi_t safi, struct prefix_rd *prd);
 
-extern int bgp_static_set(struct vty *vty, bool negate, const char *ip_str,
-			  const char *rd_str, const char *label_str, afi_t afi,
-			  safi_t safi, const char *rmap, int backdoor,
-			  uint32_t label_index, int evpn_type, const char *esi,
-			  const char *gwip, const char *ethtag,
-			  const char *routermac);
+extern int bgp_static_set(struct bgp *bgp, bool negate, const char *ip_str,
+                          const char *rd_str, const char *label_str, afi_t afi,
+                          safi_t safi, const char *rmap, int backdoor,
+                          uint32_t label_index, int evpn_type, const char *esi,
+                          const char *gwip, const char *ethtag,
+                          const char *routermac);
 
 /* this is primarily for MPLS-VPN */
 extern void bgp_update(struct peer *peer, const struct prefix *p,


### PR DESCRIPTION
## Summary
- change `bgp_static_set()` prototype to take `struct bgp *` instead of `struct vty *`
- log errors inside `bgp_static_set()` rather than printing to the CLI
- update CLI helpers to fetch the BGP context and call the new API

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68409632aaf8832981f81cd872bb6713